### PR TITLE
Add performance info to submission get

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "sivacor"
-version = "0.1.9"
+version = "0.1.10"
 description = "A tool for interacting with SIVACOR platform."
 authors = [
   {name = "Kacper Kowalik", email = "xarthisius.kk@gmail.com"},


### PR DESCRIPTION
This pull request introduces enhancements to the submission summary feature in the `sivacor` tool, specifically by integrating the display of performance metrics for each stage of a submission. The version number has also been incremented to reflect these new capabilities.

**Enhancements to submission summary:**

* Added retrieval and parsing of performance data items associated with a submission folder in `get_submission`, filtering for items of type `"performance_data"` and loading their content for later display.
* Updated the summary output to include performance metrics per stage, formatting memory usage and timestamps for readability, and skipping irrelevant metrics.

**Version update:**

* Bumped the project version from `0.1.9` to `0.1.10` in `pyproject.toml` to reflect the new features.